### PR TITLE
fixes jquery styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- Link to jquery -->
-    <!-- <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">   -->
+    <!-- Link to jquery, fix found here: https://stackoverflow.com/questions/24841028/jquery-tooltip-add-div-role-log-in-my-page-->
+    <link href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"> <!--this links the bulma-->
     <link rel="resetsheet" href="./assets/reset.css">
     <link rel="stylesheet" href="./assets/style.css">


### PR DESCRIPTION
Open HTML and type something into the search bar. You will see that the autocomplete bar only goes the length of the input, and that the search does not appear at the bottom of the page